### PR TITLE
Fix react components

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -12,7 +12,7 @@ class App extends Component {
   render() {
     return (
       <Router>
-        <div>{<MainContainer />}</div>
+        <div><MainContainer /></div>
       </Router>
     );
   }

--- a/client/actions/actions.js
+++ b/client/actions/actions.js
@@ -20,6 +20,7 @@ export const fetchItemsData = () => dispatch => {
   fetch('http://localhost:3000/allItems')
     .then(response => response.json())
     .then(data => {
+      console.log('we got the items')
       dispatch(fetchedItems(data));
     })
     .catch(() => dispatch(fetchError));

--- a/client/actions/actions.js
+++ b/client/actions/actions.js
@@ -20,7 +20,6 @@ export const fetchItemsData = () => dispatch => {
   fetch('http://localhost:3000/allItems')
     .then(response => response.json())
     .then(data => {
-      console.log(data);
       dispatch(fetchedItems(data));
     })
     .catch(() => dispatch(fetchError));

--- a/client/components/Card.jsx
+++ b/client/components/Card.jsx
@@ -10,12 +10,17 @@ import React, { Component } from 'react';
 //   }
 // }
 
-function Card(props) {
+const Card = (props) => {
+  console.log('in cards for item', props.info.item_name)
   return (
-    <div id={props.id}>
-      <p>{props.itemName}</p>
+    <div className="card" id={props.info.id}>
+      <img src={props.info.photo}></img>
+      <p>{props.info.item_name}</p>
+      <p>{props.info.price}</p>
+      <p>{props.info.item_details}</p>
+      <p>{props.info.created_at}</p>
     </div>
-  );
-}
+  )
+};
 
 export default Card;

--- a/client/components/Card.jsx
+++ b/client/components/Card.jsx
@@ -1,11 +1,21 @@
 import React, { Component } from 'react';
 
-class Card extends Component {
-  render() {
-    return (
-      <div id={props.key}>
-        <p>{this.props.itemName}</p>
-      </div>
-    );
-  }
+// class Card extends Component {
+//   render() {
+//     return (
+//       <div id={this.props.id}>
+//         <p>{this.props.itemName}</p>
+//       </div>
+//     );
+//   }
+// }
+
+function Card(props) {
+  return (
+    <div id={props.id}>
+      <p>{props.itemName}</p>
+    </div>
+  );
 }
+
+export default Card;

--- a/client/containers/CardsContainer.jsx
+++ b/client/containers/CardsContainer.jsx
@@ -35,9 +35,13 @@ function cardFunction(item) {
   );
 }
 
+function checkRender(props) {
+  if (typeof props.items === 'undefined') return null;
+  return props.items.map(cardFunction);
+}
+
 function CardsContainer(props) {
-  const cards = props.items.map(cardFunction);
-  return <div id="cards-container">{cards}</div>;
+  return <div id="cards-container">{checkRender(props)}</div>;
 }
 
 export default CardsContainer;

--- a/client/containers/CardsContainer.jsx
+++ b/client/containers/CardsContainer.jsx
@@ -23,26 +23,48 @@ const uuid = require('uuid/v1');
 //   }
 // }
 
-function cardFunction(item) {
+
+const CardsContainer = (props) => {
+  
+  console.log('here are the props inside CardsContainer ', props);
+
+  const createCard = (item) => {
+
+    console.log('in create card for: ' ,item.item_name)
+    return <Card key={uuid()} info={item}></Card>
+
+  }
+
+
+  let cards = props.items.map(createCard);
+  
+
+
   return (
-    <Card
-      itemName={item.item_name}
-      itemPrice={item.price}
-      itemPhoto={item.photo}
-      itemDetails={item.item_details}
-      key={item.id}
-    />
-  );
-}
+    <div className="card-container">
+      {cards}
+    </div>
+  )
+  
+  }
+    // <Card
+    //   itemName={item.item_name}
+    //   itemPrice={item.price}
+    //   itemPhoto={item.photo}
+    //   itemDetails={item.item_details}
+    //   key={item.id}
+    // />
+    // }
 
-function checkRender(props) {
-  console.log(props.items);
-  if (typeof props.items === 'undefined') return null;
-  return props.items.map(cardFunction);
-}
 
-function CardsContainer(props) {
-  return <div id="cards-container">{checkRender(props)}</div>;
-}
+// function checkRender(props) {
+//   console.log(props.items);
+//   if (typeof props.items === 'undefined') return null;
+//   return props.items.map(cardFunction);
+// }
+
+// function CardsContainer(props) {
+//   return <div id="cards-container">{checkRender(props)}</div>;
+// }
 
 export default CardsContainer;

--- a/client/containers/CardsContainer.jsx
+++ b/client/containers/CardsContainer.jsx
@@ -4,23 +4,40 @@ import Card from '../components/Card.jsx';
 
 const uuid = require('uuid/v1');
 
-class CardsContainer extends Component {
-  cardFunction(item) {
-    return (
-      <Card
-        itemName={item.item_name}
-        itemPrice={item.price}
-        itemPhoto={item.photo}
-        itemDetails={item.item_details}
-        key={item.id}
-      />
-    );
-  }
+// class CardsContainer extends Component {
+//   cardFunction(item) {
+//     return (
+//       <Card
+//         itemName={item.item_name}
+//         itemPrice={item.price}
+//         itemPhoto={item.photo}
+//         itemDetails={item.item_details}
+//         key={item.id}
+//       />
+//     );
+//   }
 
-  render() {
-    const cards = this.props.items.map(this.cardFunction, this);
-    return <div id="cards-container">{cards}</div>;
-  }
+//   render() {
+//     const cards = this.props.items.map(this.cardFunction, this);
+//     return <div id="cards-container">{cards}</div>;
+//   }
+// }
+
+function cardFunction(item) {
+  return (
+    <Card
+      itemName={item.item_name}
+      itemPrice={item.price}
+      itemPhoto={item.photo}
+      itemDetails={item.item_details}
+      key={item.id}
+    />
+  );
+}
+
+function CardsContainer(props) {
+  const cards = props.items.map(cardFunction);
+  return <div id="cards-container">{cards}</div>;
 }
 
 export default CardsContainer;

--- a/client/containers/CardsContainer.jsx
+++ b/client/containers/CardsContainer.jsx
@@ -12,14 +12,15 @@ class CardsContainer extends Component {
         itemPrice={item.price}
         itemPhoto={item.photo}
         itemDetails={item.item_details}
-        key={uuid()}
+        key={item.id}
       />
     );
   }
 
   render() {
-    const cards = props.cards.map(this.cardFunction, this);
-
+    const cards = this.props.items.map(this.cardFunction, this);
     return <div id="cards-container">{cards}</div>;
   }
 }
+
+export default CardsContainer;

--- a/client/containers/CardsContainer.jsx
+++ b/client/containers/CardsContainer.jsx
@@ -36,6 +36,7 @@ function cardFunction(item) {
 }
 
 function checkRender(props) {
+  console.log(props.items);
   if (typeof props.items === 'undefined') return null;
   return props.items.map(cardFunction);
 }

--- a/client/containers/MainContainer.jsx
+++ b/client/containers/MainContainer.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import Navigation from './NavigationContainer.jsx';
 import Cards from './CardsContainer.jsx';
 import types from '../constants/actionTypes';
-import actions from '../actions/actions';
+import { fetchItemsData } from '../actions/actions';
 
 const mapStateToProps = store => ({
   items: store.items,
@@ -16,7 +16,7 @@ const mapStateToProps = store => ({
 
 const mapDispatchToProps = dispatch => ({
   fetchAllItems: () => {
-    dispatch(actions.fetchItemsData());
+    dispatch(fetchItemsData());
   }
 });
 
@@ -25,7 +25,7 @@ class MainContainer extends Component {
     super(props);
   }
 
-  componentDidMount() {
+  componentWillMount() {
     this.props.fetchAllItems();
   }
 

--- a/client/containers/MainContainer.jsx
+++ b/client/containers/MainContainer.jsx
@@ -7,16 +7,17 @@ import { connect } from 'react-redux';
 import Navigation from './NavigationContainer.jsx';
 import Cards from './CardsContainer.jsx';
 import types from '../constants/actionTypes';
-import { fetchItemsData } from '../actions/actions';
+import * as actions from '../actions/actions';
 
+// use this.props.cards to access state in our components below
 const mapStateToProps = store => ({
-  items: store.items,
   cards: store.cards
 });
 
+// need to add all our action creators here
 const mapDispatchToProps = dispatch => ({
   fetchAllItems: () => {
-    dispatch(fetchItemsData());
+    dispatch(actions.fetchItemsData());
   }
 });
 
@@ -30,10 +31,10 @@ class MainContainer extends Component {
   }
 
   render() {
+    //console.log('here are ur props ',this.props.cards.items);
     return (
       <div id="cardsdiv">
-        <Cards items={this.props.items} />
-        testin
+        <Cards items={this.props.cards.items} />
       </div>
     );
   }

--- a/client/containers/MainContainer.jsx
+++ b/client/containers/MainContainer.jsx
@@ -25,7 +25,7 @@ class MainContainer extends Component {
     super(props);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.props.fetchAllItems();
   }
 

--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Moo!</title>
+    
   </head>
 
   <body>

--- a/client/index.js
+++ b/client/index.js
@@ -4,7 +4,7 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import App from './App.jsx';
 import store from './store';
-
+import styles from './styles/application.less'; 
 render(
   <Provider store={store}>
     <App />

--- a/client/reducers/cardsReducer.js
+++ b/client/reducers/cardsReducer.js
@@ -2,7 +2,7 @@
 import * as types from '../constants/actionTypes';
 
 const initialState = {
-  items: [],
+  items: [{ id: null, item_name: null, item_price: 0, item_photo: null, item_details: null }],
   user: {
     name: '',
     email: ''

--- a/client/reducers/cardsReducer.js
+++ b/client/reducers/cardsReducer.js
@@ -2,7 +2,7 @@
 import * as types from '../constants/actionTypes';
 
 const initialState = {
-  items: [{ id: null, item_name: null, item_price: 0, item_photo: null, item_details: null }],
+  items: [],
   user: {
     name: '',
     email: ''
@@ -15,6 +15,7 @@ const initialState = {
 };
 
 const cardsReducer = (state = initialState, action) => {
+  console.log('running reducer:', action.type);
   switch (action.type) {
     case types.LOGIN:
       return {
@@ -36,6 +37,7 @@ const cardsReducer = (state = initialState, action) => {
         fetching: false,
         fetched: true
       };
+
     default:
       return state;
   }

--- a/client/styles/application.less
+++ b/client/styles/application.less
@@ -1,0 +1,1 @@
+@import "styles.less";

--- a/client/styles/styles.less
+++ b/client/styles/styles.less
@@ -1,0 +1,22 @@
+.card {
+  border: 1px solid rgb(141, 141, 141);
+  border-radius: 15px;
+  width: 300px;
+  height: 300px;
+}
+
+.card img{
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 50%;
+    
+}
+
+.card-container {
+  display:flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,3 +38,4 @@ module.exports = {
   },
   plugins: [new htmlWebpackPlugin({ template: './client/index.html' })]
 };
+


### PR DESCRIPTION
### Changelog
**App.js**

- removed unnecessary curly braces

**Index.js**

- linked our LESS files to be linked throughout the app

**Styles.less**

- basic LESS stylings on the cards and cards container. 

- decided to go with flexbox for the grid styling

**webpack.config**

- added a new rule to compile LESS

- we still have the rule to compile CSS. It doesn't run anything at the moment, but it's okay to keep there IMO just in case we need to important a library that doesn't use LESS (aka paper.css)

**Main Container**

- fixed syntax of importing. It now imports all exported modules as actions and can now access each one as actions.method

- Removed items mapping from` mapStateToProps` because it didn't do anything. Inside your `reducers/index.js` , you only have one key in your combine reducers object called `cards`. So the only thing available to your store is `store.cards`

- You can now pass state down to your components as this.props.cards

**Cards Container**

- changed to ES6 arrow functions and passed in your props as props. you can now access all passed down state in `props`

- created a helper function to create a single card component

- we use the helper function and map the items array and render all the cards

**Card**

- Displayed all the card info that was passed down from CardsContainer map helper function
